### PR TITLE
Fix Other-type actors' playbooks not being displayed

### DIFF
--- a/src/module/applications/actor/actor-sheet.js
+++ b/src/module/applications/actor/actor-sheet.js
@@ -127,7 +127,9 @@ export default class PbtaActorSheet extends ActorSheet {
 				.filter((a) => a === "character" || game.pbta.sheetConfig.actorTypes[a]?.baseType === "character")
 				.length > 1;
 			context.playbooks = CONFIG.PBTA.playbooks
-				.filter((p) => !hasMultipleCharacterTypes || p.actorType === this.actor.type || p.actorType === "")
+				.filter((p) => !hasMultipleCharacterTypes
+					|| p.actorType === (this.actor.sheetType ?? this.actor.baseType)
+					|| p.actorType === "")
 				.map((p) => {
 					return { name: p.name, uuid: p.uuid };
 				});


### PR DESCRIPTION
https://discord.com/channels/170995199584108546/718595975693992017/1223061501896687687

Playbooks filtering was only checking the actor's type ("other"), not its sheet type (the other-type's actual name), which is the value set up when playbooks are read.