### PR TITLE
Fix item's invalid actorTypes

### DIFF
--- a/src/module/applications/item/item-sheet.js
+++ b/src/module/applications/item/item-sheet.js
@@ -81,8 +81,9 @@ export default class PbtaItemSheet extends ItemSheet {
 				const validCharacterType = Object.fromEntries(Object.entries(sheetConfig.actorTypes)
 					.filter(([k, v]) => [k, v?.baseType].includes(characterOrNpc) && v.moveTypes));
 				if (Object.keys(validCharacterType).length) {
-					context.system.moveTypes =
-						foundry.utils.duplicate(validCharacterType[actorType || characterOrNpc].moveTypes);
+					const moveTypes = validCharacterType[actorType]?.moveTypes
+						?? validCharacterType[characterOrNpc]?.moveTypes;
+					context.system.moveTypes = foundry.utils.duplicate(moveTypes);
 				}
 			}
 
@@ -108,7 +109,8 @@ export default class PbtaItemSheet extends ItemSheet {
 						.filter(([k, v]) => [k, v?.baseType].includes("character") && v.stats));
 
 					if (Object.keys(validCharacterType).length) {
-						context.system.stats = foundry.utils.duplicate(validCharacterType[actorType || "character"].stats);
+						const stats = validCharacterType[actorType]?.stats || validCharacterType.character?.stats;
+						context.system.stats = foundry.utils.duplicate(stats);
 					}
 				}
 				context.system.stats.prompt = { label: game.i18n.localize("PBTA.Prompt") };
@@ -129,7 +131,9 @@ export default class PbtaItemSheet extends ItemSheet {
 				context.system.rollExample = sheetConfig?.rollFormula ?? "2d6";
 			}
 		} else if (this.item.type === "equipment") {
-			context.system.equipmentTypes = sheetConfig?.actorTypes[actorType || "character"]?.equipmentTypes ?? null;
+			const equipmentTypes = sheetConfig?.actorTypes[actorType]?.equipmentTypes
+				|| sheetConfig?.actorTypes.character?.equipmentTypes;
+			context.system.equipmentTypes = equipmentTypes ?? null;
 		}
 
 		return context;

--- a/src/module/documents/item.js
+++ b/src/module/documents/item.js
@@ -169,7 +169,7 @@ export default class ItemPbta extends Item {
 			});
 		}
 		if (this.actor && this.system.actorType !== undefined) {
-			this.updateSource({ "system.actorType": this.actor.type });
+			this.updateSource({ "system.actorType": this.actor?.system?.customType ?? this.actor.type });
 		}
 
 		// Handle everything else if not imported from compendiums

--- a/src/module/migration.js
+++ b/src/module/migration.js
@@ -124,8 +124,12 @@ export function migrateActorData(actor, migrationData, flags={}) {
 
 		let itemUpdate = migrateItemData(itemData, migrationData, itemFlags);
 
-		if ((itemData.system.actorType !== undefined) && (actor.system?.actorType !== actor.type)) {
-			arr.push({ "system.actorType": actor.type, _id: itemData._id });
+		if (itemData.system.actorType !== undefined) {
+			if (itemData.system?.actorType !== (actor.system?.customType ?? actor.type)) {
+				arr.push({ "system.actorType": actor.system?.customType ?? actor.type, _id: itemData._id });
+			} else if ((actor.system?.customType && itemData.system?.actorType === "other")) {
+				arr.push({ "system.actorType": actor.system?.customType ?? actor.type, _id: itemData._id });
+			}
 		}
 
 		// Update the Owned Item

--- a/src/yaml/system.yml
+++ b/src/yaml/system.yml
@@ -52,4 +52,4 @@ download: https://asacolips-artifacts.s3.amazonaws.com/pbta/0.9.4/pbta.zip
 changelog: https://github.com/asacolips-projects/pbta/blob/main/CHANGELOG.md
 bugs: https://github.com/asacolips-projects/pbta/issues
 flags:
-  needsMigrationVersion: "0.8.2"
+  needsMigrationVersion: "0.9.4"


### PR DESCRIPTION
Items of Other-type actors were being set with its actor's type instead of their custom type, which failed to load the proper moveTypes if the item were ever moved back into the Items Directory.

This also includes a remigration for owned items of other-type actors.