### PR TITLE
Stat-shiftung Chat Bug Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist/
 /pbta/
 /pbta.zip
 foundry
+
+#OS
+.DS_Store

--- a/src/module/applications/actor/actor-sheet.js
+++ b/src/module/applications/actor/actor-sheet.js
@@ -587,7 +587,7 @@ export default class PbtaActorSheet extends ActorSheet {
 		if ((!up && !down) || (up === down)) return;
 
 		const { maxMod, minMod, statShifting } = game.pbta.sheetConfig;
-		const { labels, value } = statShifting;
+		const { stats, value } = statShifting;
 
 		const system = {};
 		let fail = false;
@@ -609,7 +609,7 @@ export default class PbtaActorSheet extends ActorSheet {
 
 		const content = await renderTemplate("systems/pbta/templates/chat/stat-shift.hbs", {
 			actor: this.actor,
-			labels,
+			stats,
 			up: up ? this.actor.system.stats[up] : "",
 			down: down ? this.actor.system.stats[down] : "",
 			fail

--- a/src/templates/chat/stat-shift.hbs
+++ b/src/templates/chat/stat-shift.hbs
@@ -1,7 +1,7 @@
 <section class="pbta-chat-card">
   <div class="cell cell--chat">
     <div class="chat-title row flexrow">
-      <h2 class="cell__title">{{localize 'PBTA.Stat.Shifting.shifts' actor=actor.name stats=labels.stats }}</h2>
+      <h2 class="cell__title">{{localize 'PBTA.Stat.Shifting.shifts' actor=actor.name stats=stats }}</h2>
     </div>
 
     <div>


### PR DESCRIPTION
- Added .DS_Store to the gitignore file
- fixed a bug in the chat output for stat shifting. Before it was passing an undefined var into the hbs now its passing the correct object.

Before:
<img width="293" alt="Foundry_Virtual_Tabletop-3" src="https://github.com/asacolips-projects/pbta/assets/727468/1427d9ce-1806-4d1d-969f-32bd62dff742">

After: 
<img width="294" alt="Foundry_Virtual_Tabletop-2" src="https://github.com/asacolips-projects/pbta/assets/727468/a935153c-73d5-4323-85d8-b17c808d9cfe">