### PR TITLE
Tag descriptions added to the on-hover when they exist

### DIFF
--- a/src/module/applications/item/item-sheet.js
+++ b/src/module/applications/item/item-sheet.js
@@ -174,6 +174,20 @@ export default class PbtaItemSheet extends ItemSheet {
 	}
 
 	/**
+	 * Allows User input of tags with descriptions in
+	 * the form of "tag name"|"tag description"
+	 * @param {any} tagData
+	 */
+	_transformTag(tagData) {
+		let parts = tagData.value.split(/\|/);
+		let value = parts[0].trim();
+		let description = parts[1]?.replace(/\|/, "").trim();
+
+		tagData.value = value;
+		tagData.description = description || tagData.description;
+	}
+
+	/**
 	 * Add tagging widget.
 	 * @param {HTMLElement} html
 	 */
@@ -196,7 +210,8 @@ export default class PbtaItemSheet extends ItemSheet {
 				},
 				templates: {
 					tag: this._tagTemplate   // <- Add a custom template so descriptions show in a tooltip
-				}
+				},
+				transformTag: this._transformTag
 			});
 		}
 	}

--- a/src/module/applications/item/item-sheet.js
+++ b/src/module/applications/item/item-sheet.js
@@ -156,6 +156,24 @@ export default class PbtaItemSheet extends ItemSheet {
 	}
 
 	/**
+	 * Adding a tag template that puts the description, if it exists otherwise 
+	 * it uses the value
+	 * @param tagData
+	 * @returns an HTML template for the tag
+	 */
+	_tagTemplate(tagData) {
+		return `
+			<tag data-tooltip="${tagData.description || ""}"
+					class="tagify__tag ${tagData.class ? tagData.class : ""}" ${this.getAttributes(tagData)}>
+				<x title='' class='tagify__tag__removeBtn' role='button' aria-label='remove tag'></x>
+				<div>
+					<span class='tagify__tag-text'>${tagData.value}</span>
+				</div>
+			</tag>
+		`;
+	}
+
+	/**
 	 * Add tagging widget.
 	 * @param {HTMLElement} html
 	 */
@@ -175,6 +193,9 @@ export default class PbtaItemSheet extends ItemSheet {
 					classname: "tags-look", // <- custom classname for this dropdown, so it could be targeted
 					enabled: 0,             // <- show suggestions on focus
 					closeOnSelect: false    // <- do not hide the suggestions dropdown once an item has been selected
+				},
+				templates: {
+					tag: this._tagTemplate   // <- Add a custom template so descriptions show in a tooltip
 				}
 			});
 		}

--- a/src/module/applications/item/item-sheet.js
+++ b/src/module/applications/item/item-sheet.js
@@ -156,10 +156,10 @@ export default class PbtaItemSheet extends ItemSheet {
 	}
 
 	/**
-	 * Adding a tag template that puts the description, if it exists otherwise 
-	 * it uses the value
-	 * @param tagData
-	 * @returns an HTML template for the tag
+	 * Adding a tag template that puts the description in the tooltip.
+	 * If the description doesn't exist, there is not tool-tip
+	 * @param {any} tagData
+	 * @returns {string} an HTML template for the tag
 	 */
 	_tagTemplate(tagData) {
 		return `

--- a/src/module/forms/tag-config.js
+++ b/src/module/forms/tag-config.js
@@ -71,10 +71,10 @@ export class PbtaTagConfigDialog extends FormApplication {
 	}
 
 	/**
-	 * Adding a tag template that puts the description, if it exists otherwise 
-	 * it uses the value
-	 * @param tagData
-	 * @returns an HTML template for the tag
+	 * Adding a tag template that puts the description in the tooltip.
+	 * If the description doesn't exist, there is not tool-tip
+	 * @param {any} tagData
+	 * @returns {string} an HTML template for the tag
 	 */
 	_tagTemplate(tagData) {
 		return `

--- a/src/module/forms/tag-config.js
+++ b/src/module/forms/tag-config.js
@@ -71,6 +71,24 @@ export class PbtaTagConfigDialog extends FormApplication {
 	}
 
 	/**
+	 * Adding a tag template that puts the description, if it exists otherwise 
+	 * it uses the value
+	 * @param tagData
+	 * @returns an HTML template for the tag
+	 */
+	_tagTemplate(tagData) {
+		return `
+			<tag data-tooltip="${tagData.description || ""}"
+					class="tagify__tag ${tagData.class ? tagData.class : ""}" ${this.getAttributes(tagData)}>
+				<x title='' class='tagify__tag__removeBtn' role='button' aria-label='remove tag'></x>
+				<div>
+					<span class='tagify__tag-text'>${tagData.value}</span>
+				</div>
+			</tag>
+		`;
+	}
+
+	/**
 	 * Add tagging widget.
 	 * @param {HTMLElement} html
 	 */
@@ -81,12 +99,18 @@ export class PbtaTagConfigDialog extends FormApplication {
 		new Tagify(html.find('input[name="userTags.general"]')[0], {
 			dropdown: {
 				enabled: false
+			},
+			templates: {
+				tag: this._tagTemplate   // <- Add a custom template so descriptions show in a tooltip
 			}
 		});
 		if (html.find('input[name="moduleTags.general"]').length) {
 			new Tagify(html.find('input[name="moduleTags.general"]')[0], {
 				dropdown: {
 					enabled: false
+				},
+				templates: {
+					tag: this._tagTemplate   // <- Add a custom template so descriptions show in a tooltip
 				}
 			});
 		}
@@ -99,6 +123,9 @@ export class PbtaTagConfigDialog extends FormApplication {
 					new Tagify(html.find(`input[name="${path}.${tag}.${t}"]`)[0], {
 						dropdown: {
 							enabled: false
+						},
+						templates: {
+							tag: this._tagTemplate   // <- Add a custom template so descriptions show in a tooltip
 						}
 					});
 				}

--- a/src/module/forms/tag-config.js
+++ b/src/module/forms/tag-config.js
@@ -89,6 +89,20 @@ export class PbtaTagConfigDialog extends FormApplication {
 	}
 
 	/**
+	 * Allows User input of tags with descriptions in
+	 * the form of "tag name"|"tag description"
+	 * @param {any} tagData
+	 */
+	_transformTag(tagData) {
+		let parts = tagData.value.split(/\|/);
+		let value = parts[0].trim();
+		let description = parts[1]?.replace(/\|/, "").trim();
+
+		tagData.value = value;
+		tagData.description = description || tagData.description;
+	}
+
+	/**
 	 * Add tagging widget.
 	 * @param {HTMLElement} html
 	 */
@@ -102,7 +116,8 @@ export class PbtaTagConfigDialog extends FormApplication {
 			},
 			templates: {
 				tag: this._tagTemplate   // <- Add a custom template so descriptions show in a tooltip
-			}
+			},
+			transformTag: this._transformTag
 		});
 		if (html.find('input[name="moduleTags.general"]').length) {
 			new Tagify(html.find('input[name="moduleTags.general"]')[0], {
@@ -111,7 +126,8 @@ export class PbtaTagConfigDialog extends FormApplication {
 				},
 				templates: {
 					tag: this._tagTemplate   // <- Add a custom template so descriptions show in a tooltip
-				}
+				},
+				transformTag: this._transformTag
 			});
 		}
 		delete userTags.general;
@@ -126,7 +142,8 @@ export class PbtaTagConfigDialog extends FormApplication {
 						},
 						templates: {
 							tag: this._tagTemplate   // <- Add a custom template so descriptions show in a tooltip
-						}
+						},
+						transformTag: this._transformTag
 					});
 				}
 			}

--- a/src/module/utils.js
+++ b/src/module/utils.js
@@ -775,6 +775,58 @@ export function parseTags(tagString) {
 	return [];
 }
 
+export class TagHandler {
+	/**
+	 * Adding a tag template that puts the description in the tooltip.
+	 * If the description doesn't exist, there is not tool-tip
+	 * @param {any} tagData
+	 * @returns {string} an HTML template for the tag
+	 */
+	static tagTemplate(tagData) {
+		return `
+			<tag data-tooltip="${tagData.description ?? ""}"
+					class="tagify__tag ${tagData.class ?? ""}" ${this.getAttributes(tagData)}>
+				<x title='' class='tagify__tag__removeBtn' role='button' aria-label='remove tag'></x>
+				<div>
+					<span class='tagify__tag-text'>${tagData.value}</span>
+				</div>
+			</tag>
+		`;
+	}
+
+	/**
+	 * Allows User input of tags with descriptions in
+	 * the form of "tag name"|"tag description"
+	 * @param {any} tagData
+	 */
+	static transformTag(tagData) {
+		let parts = tagData.value.split(/\|/);
+		let value = parts[0].trim();
+		let description = parts[1]?.replace(/\|/, "").trim();
+
+		tagData.value = value;
+		tagData.description = description || tagData.description;
+	}
+
+	static onEdit(tagify, { tag, data }) {
+		let output = data.value;
+		if (data.description) output += ` | ${data.description}`;
+		tagify.setTagTextNode(tag, output);
+	}
+
+	static get config() {
+		return {
+			a11y: {
+				focusableTags: true
+			},
+			templates: {
+				tag: this.tagTemplate   // <- Add a custom template so descriptions show in a tooltip
+			},
+			transformTag: this.transformTag
+		};
+	}
+}
+
 /**
  * Retrieves a list of Playbooks in the world and compendiums
  * and returns them as an array of names or of documents.

--- a/src/module/utils.js
+++ b/src/module/utils.js
@@ -784,11 +784,11 @@ export class TagHandler {
 	 */
 	static tagTemplate(tagData) {
 		return `
-			<tag data-tooltip="${tagData.description ?? ""}"
+			<tag data-tooltip="${game.i18n.localize(tagData.description) ?? ""}"
 					class="tagify__tag ${tagData.class ?? ""}" ${this.getAttributes(tagData)}>
 				<x title='' class='tagify__tag__removeBtn' role='button' aria-label='remove tag'></x>
 				<div>
-					<span class='tagify__tag-text'>${tagData.value}</span>
+					<span class='tagify__tag-text'>${game.i18n.localize(tagData.value)}</span>
 				</div>
 			</tag>
 		`;


### PR DESCRIPTION
- In tagify fields you can type in a "tag name" followed by a pipe character "|" then a "tag description" like so `Backpack|This is where you put all your gear` and it will add a description that will show up on the tag's tool tip.  
- In the `game.pbta.tagConfigOverride` you can add a description to a given tag and once that tag is added to an item sheet it will show up as a tool-tip.
```javascript
game.pbta.tagConfigOverride = {
        item: {
            equipment: '[{"value":"Equiptment1", "description":"this is long description."}, {"value":"Equiptment2"}]'
        }
}
```
![Screenshot 2024-05-06 at 3 56 17 PM](https://github.com/asacolips-projects/pbta/assets/727468/31e1d425-8a57-4735-949e-299309e6dc27)
