### PR TITLE
Roll dialog updates to include ongoing and forward.

### DIFF
--- a/src/module/dice/rolls.js
+++ b/src/module/dice/rolls.js
@@ -58,7 +58,7 @@ export default class RollPbtA extends Roll {
 			type: CONST.CHAT_MESSAGE_STYLES.IC,
 			content: String(this.total),
 			sound: CONFIG.sounds.dice,
-
+			conditionsConsumed: this.options.conditionsConsumed,
 			conditions: this.options.conditions,
 			choices: this.data.choices,
 			details: this.data.description,
@@ -109,24 +109,6 @@ export default class RollPbtA extends Roll {
 			this.options.conditions.push(game.i18n.localize("PBTA.Disadvantage"));
 		}
 
-		const { forward, ongoing } = this.data?.resources ?? {};
-		if (forward?.value) {
-			const fRoll = new Roll(`${forward.value}`, this.data);
-			if (!(fRoll.terms[0] instanceof OperatorTerm)) {
-				this.terms.push(new OperatorTerm({ operator: "+" }));
-			}
-			this.terms = this.terms.concat(fRoll.terms);
-			this.options.conditions.push(`${game.i18n.localize("PBTA.Forward")} (${forward.value >= 0 ? "+" : ""} ${forward.value})`);
-		}
-		if (ongoing?.value) {
-			const oRoll = new Roll(`${ongoing.value}`, this.data);
-			if (!(oRoll.terms[0] instanceof OperatorTerm)) {
-				this.terms.push(new OperatorTerm({ operator: "+" }));
-			}
-			this.terms = this.terms.concat(oRoll.terms);
-			this.options.conditions.push(`${game.i18n.localize("PBTA.Ongoing")} (${ongoing.value >= 0 ? "+" : ""} ${ongoing.value})`);
-		}
-
 		// Re-compile the underlying formula
 		this._formula = this.constructor.getFormula(this.terms);
 
@@ -162,16 +144,22 @@ export default class RollPbtA extends Roll {
 	 */
 	async configureDialog({ template, templateData = {}, title } = {}, options = {}) {
 		this.options.conditions = [];
+		this.options.conditionsConsumed = [];
+		const hasSituationalMods = this.data.resources.forward.value !== 0 || this.data.resources.ongoing.value !== 0;
+
 		const needsDialog =
 			this.data.rollType === "ask"
 			|| this.data.rollType === "prompt"
+			|| hasSituationalMods
 			|| this.data.conditionGroups.length > 0
 			|| (templateData.isStatToken && templateData.numOfToken);
 
 		if (needsDialog) {
 			templateData = foundry.utils.mergeObject(templateData, {
 				conditionGroups: this.data.conditionGroups,
-				hasPrompt: this.data.rollType === "prompt"
+				hasPrompt: this.data.rollType === "prompt",
+				hasSituationalMods: hasSituationalMods,
+				resources: this.data.resources
 			});
 
 			const content = await renderTemplate(template ?? this.constructor.EVALUATION_TEMPLATE, templateData);
@@ -246,6 +234,25 @@ export default class RollPbtA extends Roll {
 		// Customize the modifier
 		if (form?.prompt?.value) {
 			addToFormula(`${form.prompt.value}`);
+		}
+
+		if (form?.forward && form?.forward.checked) {
+			const fRoll = new Roll(`${form.forward.dataset.mod}`, this.data);
+			if (!(fRoll.terms[0] instanceof OperatorTerm)) {
+				this.terms.push(new OperatorTerm({ operator: "+" }));
+			}
+			this.terms = this.terms.concat(fRoll.terms);
+			this.options.conditions.push(`${game.i18n.localize("PBTA.Forward")} (${form.forward.dataset.mod >= 0 ? "+" : ""} ${form.forward.dataset.mod})`);
+			this.options.conditionsConsumed.push("forward");
+		}
+
+		if (form?.ongoing && form?.ongoing.checked) {
+			const oRoll = new Roll(`${form.ongoing.dataset.mod}`, this.data);
+			if (!(oRoll.terms[0] instanceof OperatorTerm)) {
+				this.terms.push(new OperatorTerm({ operator: "+" }));
+			}
+			this.terms = this.terms.concat(oRoll.terms);
+			this.options.conditions.push(`${game.i18n.localize("PBTA.Ongoing")} (${form.ongoing.dataset.mod >= 0 ? "+" : ""} ${form.ongoing.dataset.mod})`);
 		}
 
 		if (form?.condition) {

--- a/src/module/documents/actor.js
+++ b/src/module/documents/actor.js
@@ -190,7 +190,9 @@ export default class ActorPbta extends Actor {
 			title: label ?? "",
 			rollMode: game.settings.get("core", "rollMode")
 		});
-		await this.clearForwardAdv();
+		if (choice.options.conditionsConsumed.includes("forward") ?? false) {
+			await this.clearForwardAdv();
+		}
 		await this.updateCombatMoveCount();
 	}
 
@@ -220,7 +222,9 @@ export default class ActorPbta extends Actor {
 			rollMode: game.settings.get("core", "rollMode")
 		});
 		await this.update(updates);
-		await this.clearForwardAdv();
+		if (choice.options.conditionsConsumed.includes("forward") ?? false) {
+			await this.clearForwardAdv();
+		}
 		await this.updateCombatMoveCount();
 	}
 

--- a/src/module/documents/item.js
+++ b/src/module/documents/item.js
@@ -92,7 +92,7 @@ export default class ItemPbta extends Item {
 			} else if (!["ask", "prompt", "formula"].includes(rollType)) {
 				stat = rollType;
 				formula += `+ @stats.${stat}.value`;
-				if (this.actor.system.stats[stat].toggle) {
+				if (this.actor.system.stats[stat]?.toggle) {
 					const { modifier } = game.pbta.sheetConfig.statToggle;
 					formula += `${modifier >= 0 ? "+" : ""} ${modifier}`;
 				}

--- a/src/module/documents/item.js
+++ b/src/module/documents/item.js
@@ -134,7 +134,9 @@ export default class ItemPbta extends Item {
 					}
 				}
 			});
-			await this.actor?.clearForwardAdv();
+			if (choice.options.conditionsConsumed.includes("forward") ?? false) {
+				await this.actor?.clearForwardAdv();
+			}
 			await this.actor.updateCombatMoveCount();
 		}
 	}

--- a/src/styles/src/global/base/_cell.scss
+++ b/src/styles/src/global/base/_cell.scss
@@ -244,6 +244,11 @@
     }
 
   }
+
+  .cell--roll-resources label, 
+  .cell--conditions label {
+    align-items: center;
+  }
 }
 
 .cell__track {

--- a/src/templates/chat/roll-dialog.html
+++ b/src/templates/chat/roll-dialog.html
@@ -4,19 +4,18 @@
     {{/if}}
     {{#if hasPrompt}}
     <div class="cell cell--prompt">
-        <p>{{localize "PBTA.Dialog.Prompt1"}}</p>
         <div class="form-group">
             <label><strong>{{localize "PBTA.Prompt"}}</strong></label>
             <input type="text" name="prompt" value="{{prompt}}" placeholder="e.g. 1" data-dtype="Number" />
         </div>
+        <p>{{localize "PBTA.Dialog.Prompt1"}}</p>
     </div>
     {{/if}}
     {{#if conditionGroups}}
     <div class="cell cell--conditions">
-        <p>{{localize "PBTA.Dialog.ChooseConditions"}}</p>
         <ul class="no-bullets">
         {{#each conditionGroups as |conditionGroup groupKey|}}
-            <li><strong>{{conditionGroup.label}}</strong>
+            <li><strong>{{conditionGroup.label}}</strong><p>{{localize "PBTA.Dialog.ChooseConditions"}}</p>
                 <ul>
                 {{#each conditionGroup.conditions as |condition key|}}
                     <li>
@@ -39,12 +38,13 @@
     {{/if}}
     {{#if hasSituationalMods}}
     <div class="cell cell--roll-resources">
-        <p>Choose situational modifiers for this move.</p>
+        <p><b>{{localize "PBTA.Dialog.ChooseSituationalModifiersTitle"}}</b></p>
+        <p>{{localize "PBTA.Dialog.ChooseSituationalModifiers"}}</p>
         {{#if resources.forward.value}}
-        <label class="flexrow"><input type="checkbox" name="forward" data-mod="{{resources.forward.value}}" data-content="forward" /><span>Use <strong>{{resources.forward.value}}</strong> Forward.</span></label>
+        <label class="flexrow"><input type="checkbox" name="forward" data-mod="{{resources.forward.value}}" data-content="forward" /><span>{{{localize "PBTA.Dialog.ForwardMessage" value=resources.forward.value}}}</span></label>
         {{/if}}
         {{#if resources.ongoing.value}}
-        <label class="flexrow"><input type="checkbox" name="ongoing" data-mod="{{resources.ongoing.value}}" data-content="ongoing" /><span>Use <strong>{{resources.ongoing.value}}</strong> Ongoing.</span></label>
+        <label class="flexrow"><input type="checkbox" name="ongoing" data-mod="{{resources.ongoing.value}}" data-content="ongoing" /><span>{{{localize "PBTA.Dialog.OngoingMessage" value=resources.ongoing.value}}}</span></label>
         {{/if}}
     </div>
     {{/if}}

--- a/src/templates/chat/roll-dialog.html
+++ b/src/templates/chat/roll-dialog.html
@@ -20,7 +20,7 @@
                 <ul>
                 {{#each conditionGroup.conditions as |condition key|}}
                     <li>
-                        <label><input type="checkbox" name="condition" data-mod="{{condition.mod}}" data-content="{{condition.label}}" />{{condition.label}}</label>
+                        <label class="flexrow"><input type="checkbox" name="condition" data-mod="{{condition.mod}}" data-content="{{condition.label}}" />{{condition.label}}</label>
                     </li>
                 {{/each}}
                 </ul>
@@ -35,6 +35,17 @@
         <div class="cell__wrapper">
             <input type="number" name="prompt" value="{{numOfToken}}" min="0" max="{{numOfToken}}" data-dtype="Number" />
         </div>
+    </div>
+    {{/if}}
+    {{#if hasSituationalMods}}
+    <div class="cell cell--roll-resources">
+        <p>Choose situational modifiers for this move.</p>
+        {{#if resources.forward.value}}
+        <label class="flexrow"><input type="checkbox" name="forward" data-mod="{{resources.forward.value}}" data-content="forward" /><span>Use <strong>{{resources.forward.value}}</strong> Forward.</span></label>
+        {{/if}}
+        {{#if resources.ongoing.value}}
+        <label class="flexrow"><input type="checkbox" name="ongoing" data-mod="{{resources.ongoing.value}}" data-content="ongoing" /><span>Use <strong>{{resources.ongoing.value}}</strong> Ongoing.</span></label>
+        {{/if}}
     </div>
     {{/if}}
 </form>

--- a/src/templates/chat/roll-dialog.html
+++ b/src/templates/chat/roll-dialog.html
@@ -7,15 +7,17 @@
         <div class="form-group">
             <label><strong>{{localize "PBTA.Prompt"}}</strong></label>
             <input type="text" name="prompt" value="{{prompt}}" placeholder="e.g. 1" data-dtype="Number" />
+            <p class="notes">{{localize "PBTA.Dialog.Prompt1"}}</p>
         </div>
-        <p>{{localize "PBTA.Dialog.Prompt1"}}</p>
     </div>
     {{/if}}
     {{#if conditionGroups}}
     <div class="cell cell--conditions">
         <ul class="no-bullets">
         {{#each conditionGroups as |conditionGroup groupKey|}}
-            <li><strong>{{conditionGroup.label}}</strong><p>{{localize "PBTA.Dialog.ChooseConditions"}}</p>
+            <li>
+                <strong>{{conditionGroup.label}}</strong>
+                <p class="notes">{{localize "PBTA.Dialog.ChooseConditions"}}</p>
                 <ul>
                 {{#each conditionGroup.conditions as |condition key|}}
                     <li>
@@ -38,8 +40,8 @@
     {{/if}}
     {{#if hasSituationalMods}}
     <div class="cell cell--roll-resources">
-        <p><b>{{localize "PBTA.Dialog.ChooseSituationalModifiersTitle"}}</b></p>
-        <p>{{localize "PBTA.Dialog.ChooseSituationalModifiers"}}</p>
+        <strong>{{localize "PBTA.Dialog.ChooseSituationalModifiersTitle"}}</strong>
+        <p class="notes">{{localize "PBTA.Dialog.ChooseSituationalModifiers"}}</p>
         {{#if resources.forward.value}}
         <label class="flexrow"><input type="checkbox" name="forward" data-mod="{{resources.forward.value}}" data-content="forward" /><span>{{{localize "PBTA.Dialog.ForwardMessage" value=resources.forward.value}}}</span></label>
         {{/if}}

--- a/src/yaml/lang/en.yml
+++ b/src/yaml/lang/en.yml
@@ -77,6 +77,10 @@ PBTA:
   Dialog:
     Ask1: "Choose a stat for this move."
     ChooseConditions: "Choose all conditional modifiers that apply:"
+    ChooseSituationalModifiersTitle: "Situational Modifiers"
+    ChooseSituationalModifiers: "Choose all situational modifiers that apply:"
+    ForwardMessage: "Use <strong>{value}</strong> Forward."
+    OngoingMessage: "Use <strong>{value}</strong> Ongoing."
     Prompt1: "Choose the modifier for this move."
     HowManyToken: "How many token would you like to use?"
     ErrorAboveMax: "You can't spend more token than you have."


### PR DESCRIPTION
- Added Ongoing and Forward to the roll dialog if they have a value that is not zero. 
- Forward still gets consumed if used, but doesn't get consumed if not chosen
![Foundry_Virtual_Tabletop](https://github.com/asacolips-projects/pbta/assets/727468/cef89afd-8935-4c1a-b5ba-da6565b6d076)

