### PR TITLE
Release 1.0.19

### DIFF
--- a/release-notes/1.0.19.md
+++ b/release-notes/1.0.19.md
@@ -8,6 +8,8 @@ _Manifest URL_: https://asacolips-artifacts.s3.amazonaws.com/pbta/1.0.19/system.
 - Limited Actor sheets should now have their Playbook CSS.
 - Actor Sheet's Description fields now have their key added to CSS. E.g. Biography's `cell cell--bio` is now `cell cell--bio biography`.
 - Playbooks' Item Grants now support Babele.
+- Sheet Config: Roll attributes now have an optional `showResults` property, which shows/hides results.
 
 ## Fixes
 - Fixed Playbooks missing from the dropdown list if Babele is active and its hook was missed.
+- Fixed Sheet Config warning about cosmetic changes to any attribute with an Array-type `playbook` property.

--- a/release-notes/1.0.19.md
+++ b/release-notes/1.0.19.md
@@ -1,0 +1,13 @@
+## Downloads
+_Manifest URL_: https://asacolips-artifacts.s3.amazonaws.com/pbta/1.0.19/system.json
+
+## Compatible Foundry Versions
+![Foundry v12](https://img.shields.io/badge/Foundry-v12-green) ![Foundry v12](https://img.shields.io/badge/Foundry-v12-orange)
+
+## Changed
+- Limited Actor sheets should now have their Playbook CSS.
+- Actor Sheet's Description fields now have their key added to CSS. E.g. Biography's `cell cell--bio` is now `cell cell--bio biography`.
+- Playbooks' Item Grants now support Babele.
+
+## Fixes
+- Fixed Playbooks missing from the dropdown list if Babele is active and its hook was missed.

--- a/src/module/applications/actor/actor-sheet.js
+++ b/src/module/applications/actor/actor-sheet.js
@@ -62,11 +62,9 @@ export default class PbtaActorSheet extends ActorSheet {
 	/* -------------------------------------------- */
 
 	render(force=false, options={}) {
-		if (!this.actor.limited) {
-			const playbook = this.actor.playbook.slug;
-			if (playbook && !(this.options.classes.includes(`playbook-${playbook}`))) {
-				this.options.classes.push(`playbook-${playbook}`);
-			}
+		const playbook = this.actor.playbook.slug;
+		if (playbook && !(this.options.classes.includes(`playbook-${playbook}`))) {
+			this.options.classes.push(`playbook-${playbook}`);
 		}
 		return super.render(force, options);
 	}

--- a/src/module/applications/actor/actor-sheet.js
+++ b/src/module/applications/actor/actor-sheet.js
@@ -209,6 +209,9 @@ export default class PbtaActorSheet extends ActorSheet {
 				context.system[position][attrKey].enriched =
 					await TextEditor.enrichHTML(attrValue.value, context.enrichmentOptions);
 			}
+			if (attrValue.type === "Roll" && attrValue.showResults === undefined) {
+				attrValue.showResults = true;
+			}
 		}
 	}
 

--- a/src/module/applications/actor/actor-sheet.js
+++ b/src/module/applications/actor/actor-sheet.js
@@ -132,6 +132,7 @@ export default class PbtaActorSheet extends ActorSheet {
 					.filter(([k, v]) => [k, v?.baseType].includes("character"))
 			);
 			const hasMultipleCharacterTypes = Object.keys(validCharacterTypes).length > 1;
+			if (!CONFIG.PBTA.playbooks.length && !game.pbta.noPlaybooks) await game.pbta.utils.getPlaybooks();
 			context.playbooks = CONFIG.PBTA.playbooks
 				.filter((p) => !hasMultipleCharacterTypes || [this.actor.sheetType, ""].includes(p.actorType))
 				.map((p) => {

--- a/src/module/applications/item/playbook-sheet.js
+++ b/src/module/applications/item/playbook-sheet.js
@@ -27,12 +27,18 @@ export default class PlaybookSheet extends PbtaItemSheet {
 			1: "PBTA.PlaybookGrantOnAdvancement"
 		};
 		const choicesByAdvancement = {};
-		this.item.system.choiceSets.forEach((cs, index) => {
+		await Promise.all(this.item.system.choiceSets.map(async (cs, index) => {
+			await Promise.all(cs.choices.map(async (c) => {
+				const { name } = await fromUuid(c.uuid);
+				c.name = name;
+			}));
+
 			if (!choicesByAdvancement[cs.advancement]) choicesByAdvancement[cs.advancement] = {};
 			if (!choicesByAdvancement[cs.advancement][index]) choicesByAdvancement[cs.advancement][index] = [];
 			choicesByAdvancement[cs.advancement][index].push(cs);
-		});
+		}));
 		context.choicesByAdvancement = choicesByAdvancement;
+
 		for (let [k, v] of Object.entries(context.system.attributes)) {
 			if (["Details", "LongText"].includes(v.type) && context.system.attributes[k].choices) {
 				for (const choice of context.system.attributes[k].choices) {
@@ -216,7 +222,7 @@ export default class PlaybookSheet extends PbtaItemSheet {
 			if (moveTypes?.[item.system.moveType]?.creation) return false;
 		}
 
-		const { img, name, type, uuid } = item;
+		const { img, type, uuid } = item;
 
 		const { id: setId } = event.target.closest(".choiceset").dataset;
 		const choiceSets = this.item.system.choiceSets;
@@ -232,7 +238,6 @@ export default class PlaybookSheet extends PbtaItemSheet {
 				.filter((c) => c.uuid !== uuid);
 		}
 		choiceSets[setId].choices.push({
-			name,
 			img,
 			uuid,
 			granted: false,

--- a/src/module/data/item/playbook.js
+++ b/src/module/data/item/playbook.js
@@ -54,7 +54,6 @@ export default class PlaybookData extends ItemTemplateData {
 						new foundry.data.fields.SchemaField({
 							uuid: new foundry.data.fields.StringField({ initial: "", required: true }),
 							img: new foundry.data.fields.StringField({ initial: null, nullable: true }),
-							name: new foundry.data.fields.StringField({ initial: null, nullable: true }),
 							granted: new foundry.data.fields.BooleanField({ initial: false }),
 							advancement: new foundry.data.fields.NumberField({
 								required: true,

--- a/src/module/dice/rolls.js
+++ b/src/module/dice/rolls.js
@@ -42,13 +42,14 @@ export default class RollPbtA extends Roll {
 
 		const resultRanges = game.pbta.sheetConfig.rollResults;
 		let resultType = null;
-
-		// Iterate through each result range until we find a match.
-		for (let [resultKey, resultRange] of Object.entries(resultRanges)) {
-			let { start, end } = resultRange;
-			if ((!start || this.total >= start) && (!end || this.total <= end)) {
-				resultType = resultKey;
-				break;
+		if (!this.options.descriptionOnly) {
+			// Iterate through each result range until we find a match.
+			for (let [resultKey, resultRange] of Object.entries(resultRanges)) {
+				let { start, end } = resultRange;
+				if ((!start || this.total >= start) && (!end || this.total <= end)) {
+					resultType = resultKey;
+					break;
+				}
 			}
 		}
 

--- a/src/module/documents/actor.js
+++ b/src/module/documents/actor.js
@@ -124,7 +124,7 @@ export default class ActorPbta extends Actor {
 	 * @param {MouseEvent} event
 	 */
 	async _onRoll(event) {
-		const { label, roll } = event.currentTarget.dataset;
+		const { label, roll, showResults } = event.currentTarget.dataset;
 		const itemId = event.currentTarget.closest(".item")?.dataset.itemId;
 		const options = {};
 		if (!game.settings.get("pbta", "hideRollMode")) {
@@ -137,6 +137,7 @@ export default class ActorPbta extends Actor {
 			if (stat === "token" && game.pbta.sheetConfig.statToken) await this._onRollToken(stat, label, options);
 			else await this._onRollStat(stat, label, options);
 		} else if (event.currentTarget.classList.contains("attr-rollable") && roll) {
+			if (showResults === "false") options.descriptionOnly = true;
 			await this._onRollAttr(roll, label, options);
 		} else if (itemId) {
 			const item = this.items.get(itemId);

--- a/src/module/documents/item.js
+++ b/src/module/documents/item.js
@@ -36,9 +36,8 @@ export default class ItemPbta extends Item {
 	/**
 	 * Roll the item to Chat, creating a chat card which contains follow up attack or damage roll options
 	 * @param {object} options
-	 * @param {boolean} options.descriptionOnly
 	 */
-	async roll(options = { descriptionOnly: false }) {
+	async roll(options = {}) {
 		if (
 			options.descriptionOnly
 			|| this.type === "equipment"
@@ -61,7 +60,6 @@ export default class ItemPbta extends Item {
 				speaker: ChatMessage.getSpeaker({ actor: this.actor })
 			});
 		} else {
-			delete options.descriptionOnly;
 			const formula = this._getRollFormula(options);
 			options = foundry.utils.mergeObject(options, {
 				choices: this.system.choices,

--- a/src/module/documents/item.js
+++ b/src/module/documents/item.js
@@ -320,14 +320,16 @@ export default class ItemPbta extends Item {
 			for (const choiceSet of data.system.choiceSets) {
 				const { advancement, choices, desc, granted, repeatable, title } = choiceSet;
 				if (advancement > this.parent.advancement || (granted && !repeatable)) continue;
-				const validChoices = await Promise.all(
-					choices.filter(async (c) => {
+				const validChoices = (await Promise.all(
+					choices.map(async (c) => {
 						const item = await fromUuid(c.uuid);
-						return !c.granted
+						c.name = item.name;
+						const isValid = !c.granted
 							&& c.advancement <= this.parent.advancements
 							&& !this.actor.items.has(item.id);
-					})
-				);
+						return isValid ? c : null;
+					}))
+				).filter((c) => c);
 				if (!validChoices.length) continue;
 				if (choiceSet.grantOn === 0) {
 					validChoices.forEach((i) => {

--- a/src/module/forms/sheet-config.js
+++ b/src/module/forms/sheet-config.js
@@ -205,10 +205,16 @@ export class PbtaSettingsConfigDialog extends FormApplication {
 					} else {
 						const cosmetic = ["label", "customLabel", "description", "playbook", "limited"];
 						cosmetic.forEach((v) => {
-							const isValid = !foundry.utils.isEmpty(newGroup[attr][v]);
-							if (isValid && newGroup[attr][v] !== oldGroup[attr][v]) {
+							const newProp = newGroup[attr][v];
+							const oldProp = oldGroup[attr][v];
+							const isValid = !foundry.utils.isEmpty(newProp);
+							if (
+								isValid
+								&& !(newProp.equals?.(oldProp) ?? true)
+								&& newProp !== oldProp
+							) {
 								configDiff.safe.push(`${actorType}.${attrGroup}.${attr}.${v}`);
-								updatesDiff[actorType][`system.${attrGroup}.${attr}.${v}`] = newGroup[attr][v];
+								updatesDiff[actorType][`system.${attrGroup}.${attr}.${v}`] = newProp;
 							}
 						});
 						// Handle updating ListOne values.

--- a/src/module/forms/sheet-config.js
+++ b/src/module/forms/sheet-config.js
@@ -335,6 +335,11 @@ export class PbtaSettingsConfigDialog extends FormApplication {
 									updatesDiff[actorType][`system.${attrGroup}.${attr}.value`] = newGroup[attr].value ?? 0;
 									updatesDiff[actorType][`system.${attrGroup}.${attr}.steps`] = newGroup[attr].steps;
 								}
+							} else if (newType === "Roll") {
+								if (newGroup[attr].showResults !== oldGroup[attr].showResults) {
+									configDiff.safe.push(`${actorType}.${attrGroup}.${attr}.showResults`);
+									updatesDiff[actorType][`system.${attrGroup}.${attr}.showResults`] = newGroup[attr].showResults ?? true;
+								}
 							}
 						}
 					}

--- a/src/module/utils.js
+++ b/src/module/utils.js
@@ -483,8 +483,12 @@ export function convertAttr(attrGroup, position) {
 
 			case "Text":
 			case "LongText":
+				attr.value = attrValue.default ?? "";
+				break;
+
 			case "Roll":
 				attr.value = attrValue.default ?? "";
+				attr.showResults = attrValue.showResults ?? true;
 				break;
 
 			case "Checkbox":

--- a/src/module/utils.js
+++ b/src/module/utils.js
@@ -844,6 +844,7 @@ export async function getPlaybooks() {
 				actorType: p.system.actorType
 			};
 		});
+	if (!CONFIG.PBTA.playbooks.length) game.pbta.noPlaybooks = true;
 }
 
 /**

--- a/src/templates/actors/parts/actor-attributes.hbs
+++ b/src/templates/actors/parts/actor-attributes.hbs
@@ -86,7 +86,9 @@
 				</ul>
 			{{else if (eq attr.type "Roll")}}
 				<div class="cell__roll">
-					<span class="attr-icon attr-rollable rollable" data-roll="{{attr.value}}" data-label="{{attr.label}}"><i class="fas fa-dice-d6"></i> <i class="fas fa-dice-d6"></i></span>
+					<span class="attr-icon attr-rollable rollable" data-roll="{{attr.value}}" data-label="{{attr.label}}" data-show-results="{{attr.showResults}}">
+						<i class="fas fa-dice-d6"></i> <i class="fas fa-dice-d6"></i>
+					</span>
 					<input type="text" class="input input--roll" name="system.attributes.{{key}}.value" value="{{attr.value}}"/>
 				</div>
 			{{else if (eq attr.type "Track")}}

--- a/src/templates/actors/parts/actor-description.hbs
+++ b/src/templates/actors/parts/actor-description.hbs
@@ -1,7 +1,7 @@
 <div class="tab description" data-group="primary" data-tab="description">
 	<div class="sheet-tab">
 		{{#each system.details as |result key|}}
-			<div class="cell cell--bio">
+			<div class="cell cell--bio {{key}}">
 				{{#if result.label}}<label class="cell__title">{{result.label}}</label>{{/if}}
 				{{editor result.enriched target=(concat "system.details" key "value" join=".") button=true owner=../owner editable=../editable}}
 			</div>

--- a/src/yaml/system.yml
+++ b/src/yaml/system.yml
@@ -2,7 +2,7 @@ name: pbta
 id: pbta
 title: Powered by the Apocalypse
 description: Run games for any PbtA system in Foundry VTT!
-version: "1.0.18"
+version: "1.0.19"
 compatibility:
   minimum: "12"
   verified: "12"


### PR DESCRIPTION
## Changed
- Limited Actor sheets should now have their Playbook CSS.
- Actor Sheet's Description fields now have their key added to CSS. E.g. Biography's `cell cell--bio` is now `cell cell--bio biography`.
- Playbooks' Item Grants now support Babele.

## Fixes
- Fixed Playbooks missing from the dropdown list if Babele is active and its hook was missed.