### PR TITLE
Update Portuguese translations for ongoing and hold

### DIFF
--- a/src/yaml/lang/pt-br.yml
+++ b/src/yaml/lang/pt-br.yml
@@ -146,7 +146,8 @@ PBTA:
   MoveGroupHelp: Movimentos com o mesmo nome de grupo serão opções quando estiver
     criando um personagem usando o criador de personagens.
   Forward: Adiante
-  Ongoing: Constante
+  Ongoing: Contínuo
+  Hold: Reserve
   RollFormulaOverride: Rolar com a Fórmula
   Create: Criar
   New: Novo


### PR DESCRIPTION
Hello, I saw that the translation of Hold was missing in the context of movements, I also changed the translation of Ongoing to a more suitable word