### PR TITLE
Fix invalid ChatMessage type in stat-shift chat card

### DIFF
--- a/src/module/applications/actor/actor-sheet.js
+++ b/src/module/applications/actor/actor-sheet.js
@@ -660,8 +660,7 @@ export default class PbtaActorSheet extends foundry.appv1.sheets.ActorSheet {
 		ChatMessage.create({
 			user: game.user.id,
 			content: content,
-			speaker: ChatMessage.getSpeaker({ actor: this.actor }),
-			type: CONST.CHAT_MESSAGE_STYLES.OTHER
+			speaker: ChatMessage.getSpeaker({ actor: this.actor })
 		});
 	}
 


### PR DESCRIPTION
## Summary
- `_onStatShiftClick` in `actor-sheet.js` passed `CONST.CHAT_MESSAGE_STYLES.OTHER` (which is `0`) into the `ChatMessage.create` payload's `type` field.
- Since Foundry v12, `ChatMessage.type` is a document sub-type string (e.g. `"base"`), not the numeric chat style — the numeric value belongs in a separate `style` field instead.
- On v13/v14 this now fails schema validation with `SchemaField#_validateRecursive type: "0" is not a valid type for the ChatMessage document class`, which breaks the stat-shift confirmation chat card (and the "Shift Labels" sheet flow) entirely.
- Fix: drop the invalid `type` field and let it default, matching the existing `ChatMessage.create` call in `item.js`, which never sets `type`.

## Test plan
- [x] Reproduced the validation error on Foundry v14 by clicking "Shift Labels" on an actor sheet, selecting an up/down stat shift, and confirming.
- [x] Applied the fix, rebuilt (`npm run build`), reloaded Foundry, and confirmed the shift now completes with no console error and the stat-shift chat card renders correctly.

## Screenshots 

After testing, no longer hits errors on the shift labels button in the Masks PBTA module:
<img width="297" height="112" alt="image" src="https://github.com/user-attachments/assets/19118137-bd50-473e-8124-f30cbbb4dde6" />
